### PR TITLE
Update 10.0.5: OpenEthereum v3.2.6

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,3 @@
-FROM openethereum/openethereum:v3.2.5
+FROM openethereum/openethereum:v3.2.6
     
 ENTRYPOINT /home/openethereum/openethereum --port 30306 --jsonrpc-port=8545 --jsonrpc-cors=all --jsonrpc-interface=all --jsonrpc-hosts=all --jsonrpc-apis=web3,eth,net,parity --ws-interface=all --ws-apis=web3,eth,net,parity,pubsub --ws-origins=all --ws-hosts=all --ws-max-connections=10 --max-peers=100 ${EXTRA_OPTS}

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -11,12 +11,12 @@
       "data:/data"
     ],
     "restart": "always",
-    "path": "openethereum.avado.dnp.dappnode.eth_10.0.4.tar.xz",
-    "hash": "/ipfs/Qmedagpcr7VNNxM1dxxUTix44H2hw85sKtKVSYG9i2XJeQ",
-    "size": 10728252
+    "path": "openethereum.avado.dnp.dappnode.eth_10.0.5.tar.xz",
+    "hash": "/ipfs/QmdR3pSfhWgfPGSDbZsZRMQWyXeE4662zSsDFoQYf2XxtK",
+    "size": 10745040
   },
   "name": "openethereum.avado.dnp.dappnode.eth",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "shortDescription": "Ethereum client based on OpenEthereum (formerly Parity)",
   "description": "This is al alternative Ethereum client based on OpenEthereum. On you AVADO you need to run only one ethereum client. The default client is Geth - but if you want an alternative, here it is. Please uninstall Geth or Nethermind clients before adding this one.",
   "type": "service",
@@ -24,7 +24,7 @@
   "license": "GPL-3.0",
   "avatar": "/ipfs/QmZRPp5G8xmGaTw6vtYc73JkUrc72WZjH5sj9heDWVMn6C",
   "autoupdate": true,
-  "upstream": "v3.2.5",
+  "upstream": "v3.2.6",
   "title": "OpenEthereum node (mainnet)",
   "builddate": "2021-05-15T11:03:36.472Z"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   openethereum.avado.dnp.dappnode.eth:
-    image: 'openethereum.avado.dnp.dappnode.eth:10.0.4'
+    image: 'openethereum.avado.dnp.dappnode.eth:10.0.5'
     build: ./build
     volumes:
       - 'data:/root/.local/share/io.parity.ethereum'

--- a/releases.json
+++ b/releases.json
@@ -1,0 +1,9 @@
+{
+  "10.0.5": {
+    "hash": "/ipfs/QmUg1Rozr5i1hBcHdthoKn1BpYLetMoWKxKY7A3g5i2K4Y",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Mon, 24 May 2021 08:16:35 GMT"
+    }
+  }
+}


### PR DESCRIPTION
See https://github.com/openethereum/openethereum/releases/tag/v3.2.6:
```
Enhancement:

Berlin hardfork blocks: poacore (21,364,900), poasokol (21,050,600)
```
```
DNP (DAppNode Package) built and uploaded 
  Manifest hash : /ipfs/QmUg1Rozr5i1hBcHdthoKn1BpYLetMoWKxKY7A3g5i2K4Y
  http://my.dappnode/#/installer/%2Fipfs%2FQmUg1Rozr5i1hBcHdthoKn1BpYLetMoWKxKY7A3g5i2K4Y
```